### PR TITLE
Improve responsive layout of UCP page

### DIFF
--- a/styles/prosilver/template/ucp_postbookmark_body.html
+++ b/styles/prosilver/template/ucp_postbookmark_body.html
@@ -15,14 +15,14 @@
 <!-- IF .postrow -->
 	<ul class="topiclist missing-column">
 		<li class="header">
-			<dl class="row-item">
-				<dt><div class="list-inner with-mark">{L_BOOKMARKS}</div></dt>
-				<dd class="lastpost"><span>{L_COMMENT}</span></dd>
+			<dl>
+				<dt><div class="list-inner">{L_BOOKMARKS}</div></dt>
+				<dd class="info"><span>{L_COMMENT}</span></dd>
 				<dd class="mark">{L_MARK}</dd>
 			</dl>
 		</li>
 	</ul>
-	<ul class="topiclist cplist">
+	<ul class="topiclist cplist missing-column">
 
 	<!-- BEGIN postrow -->
 		<li class="row<!-- IF postrow.S_POST_REPORTED --> reported<!-- ELSEIF postrow.S_ROW_COUNT is odd --> bg1<!-- ELSE --> bg2<!-- ENDIF -->">
@@ -33,14 +33,16 @@
 			<!-- ELSE -->
 			<dl>
 				<dt>
-					<div class="list-inner with-mark">
-						<a href="{postrow.U_VIEW_POST}" class="topictitle">{postrow.POST_TITLE}</a><br />
-						{L_POST_BY_AUTHOR} {postrow.TOPIC_AUTHOR} &raquo; {postrow.POST_TIME}
+					<div class="list-inner">
+						<a class="topictitle" href="{postrow.U_VIEW_POST}">{postrow.POST_TITLE}</a><br />
+						{L_POST_BY_AUTHOR}{L_COLON} {postrow.TOPIC_AUTHOR} &raquo; {postrow.POST_TIME}
+						<div class="responsive-show" style="display: none;">
+							{L_COMMENT}{L_COLON} {postrow.BOOKMARK_DESC}<br />
+							{L_ADDED}{L_COLON} {postrow.BOOKMARK_TIME}
+						</div>
 					</div>
 				</dt>
-				<dd class="lastpost"><span><dfn>{L_LAST_POST} </dfn> {postrow.BOOKMARK_DESC}
-					<br />{L_ADDED}&raquo; {postrow.BOOKMARK_TIME}</span>
-				</dd>
+				<dd class="info"><span>{L_COMMENT}{L_COLON} {postrow.BOOKMARK_DESC}<br />{L_ADDED}{L_COLON} {postrow.BOOKMARK_TIME}</span></dd>
 				<dd class="mark"><input type="checkbox" name="t[{postrow.POST_ID}]" id="t{postrow.POST_ID}" /></dd>
 			</dl>
 			<!-- ENDIF -->


### PR DESCRIPTION
Improved layout of the UCP page on small screens, especially for styles that inherit from prosilver (e.g. we_universal).
The changed html is based on the UCP "Manage Drafts" tab.