### PR TITLE
Allow disable of native bookmarks

### DIFF
--- a/event/listener.php
+++ b/event/listener.php
@@ -91,7 +91,7 @@ class listener implements EventSubscriberInterface
 
 	public function get_topic_data($event)
 	{
-		if ($this->user->data['is_registered'] && $this->config['allow_bookmarks'])
+		if ($this->user->data['is_registered']&& !$this->user->data['is_bot'])
 		{
 			$topic_data = $event['topic_data'];
 			$posts_bookmark = array();
@@ -118,7 +118,7 @@ class listener implements EventSubscriberInterface
 
 	public function modify_post_row($event)
 	{
-		if ($this->user->data['is_registered'] && $this->config['allow_bookmarks'])
+		if ($this->user->data['is_registered'] && !$this->user->data['is_bot'])
 		{
 			$row = $event['row'];
 			$post_row = $event['post_row'];


### PR DESCRIPTION
This patch allows the extension to work even if the native phpBB bookmark feature is disabled (which I think is the best setting to avoid confusion for users).

It also stops operation of the feature for Bots.